### PR TITLE
Implement current(-c / --current) option

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ A tool to generate your timesheet from a git log. Put it in your `~/bin`!
         -s, --since [TIME]               Start date for the report (default is 1 week ago)
         -a, --author [EMAIL]             User for the report (default is the author set in git config)
             --authors                    List all available authors
+        -c, --current [CURRENT]          Only use `git log` for current branch
 
 ## Changelog
 


### PR DESCRIPTION
- Return git commits from all branches by using the `git log --all` command by default if user does not specify `-c` or `--current` Option.

- Update README to reflect Option changes.

@leonid-shevtsov If you would rather the default behavior be `git log` when no Option are specified, and the user must specify a `-b` `--branches` (or something similar) Option to run `git log --all` let me know and I will change it.
